### PR TITLE
fix(templates): fix c-project template's makefile

### DIFF
--- a/utils/templates/c-project/Makefile
+++ b/utils/templates/c-project/Makefile
@@ -195,10 +195,12 @@ $(TARGET_DIR)/%.o: $(SOURCE_DIR)/%.c
 # ------------------------
 
 post_compilation_cleanup:
+ifneq($(OBJECTS),)
 	$(SET_YELLOW_TEXT)
 	@echo "$(BINARY): Cleaning up leftovers..."
 	$(SET_WHITE_TEXT)
 	@rm $(OBJECTS)
+endif
 
 # Compilation Done
 # ----------------


### PR DESCRIPTION
Add a check for object files existence to the post_compilation_cleanup rule.

Closes: #3